### PR TITLE
SBT expects a colon instead of a slash

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Build your own binaries from the sources with
 
     $ git clone https://github.com/alexarchambault/jupyter-scala.git
     $ cd jupyter-scala
-    $ sbt cli/packArchive
+    $ sbt cli:packArchive
 
 This will generate a tar archive like `jupyter-scala-cli-0.2.0-SNAPSHOT.tar.gz` in `cli/target/`. See the instructions above for how to set it up then.
 


### PR DESCRIPTION
SBT expects a colon instead of a slash:
```
11:24 $ sbt cli/packArchive
[info] Loading project definition from /Users/fokkodriesprong/Desktop/jupyter-scala/project
[info] Set current project to jupyter-scala (in build file:/Users/fokkodriesprong/Desktop/jupyter-scala/)
[error] Expected ID character
[error] Not a valid command: cli (similar: alias, plugin)
[error] Expected project ID
[error] Expected configuration
[error] Expected ':' (if selecting a configuration)
[error] Expected key
[error] Not a valid key: cli (similar: clean, doc)
[error] cli/packArchive
[error]    ^
```

This is super confusing for people who do not work with SBT.