### PR TITLE
Do not abort on duplicated jar in spark 2.1.x.

### DIFF
--- a/spark/core/src/main/scala/jupyter/spark/package.scala
+++ b/spark/core/src/main/scala/jupyter/spark/package.scala
@@ -3,6 +3,8 @@ package jupyter
 import java.io.IOException
 import java.net.ServerSocket
 
+import util.Try
+
 import ammonite.repl.RuntimeAPI
 import ammonite.runtime.InterpAPI
 import jupyter.spark.internals.Spark
@@ -138,12 +140,12 @@ package object spark {
           sc.getConf.getOption("spark.jars").toSeq.flatMap(_.split(','))
 
       for (jar <- jars.map(_.getAbsolutePath) if !alreadyAdded(jar))
-        sc.addJar(jar)
+        Try(sc.addJar(jar))
 
       interpApi.load.onJarAdded { jars =>
         if (!sc.isStopped)
           for (jar <- jars.map(_.getAbsolutePath) if !alreadyAdded(jar))
-            sc.addJar(jar)
+            Try(sc.addJar(jar))
       }
 
       runtimeApi.onExit { _ =>


### PR DESCRIPTION
Whereas spark 2.0 would log a warning and move on when a duplicated jar was added, in spark 2.1 the behavior now is to throw an exception. See https://github.com/alexarchambault/ammonium/issues/64 for a similar problem.

Since the addJar calls happen in `JupyterSparkSession.builder().getOrCreate()`, it is very hard to recover from this exception in a meaningful way, since there is no way to prevent the addJar calls from happening, or even doing them manually later. Since in my scenario I add many jars, and I cannot predict which ones are duplicate, this is a blocker in my usage of jupter-scala.

I will be happy to polish this change if this solution is acceptable, or to pursue a different path.