### PR TITLE
Add `.XXXXXXXX` suffix to `mktemp` command.

### DIFF
--- a/jupyter-scala
+++ b/jupyter-scala
@@ -10,7 +10,7 @@ if which coursier >/dev/null; then
   COURSIER=coursier
 else
   GLOBAL_COURSIER=false
-  COURSIER="$(mktemp -t coursier)"
+  COURSIER="$(mktemp -t coursier.XXXXXXXX)"
   trap "{ rm -f \"$COURSIER\"; }" EXIT
   echo "Getting coursier launcher..." 2>&1
   curl -s -L -o "$COURSIER" https://github.com/coursier/coursier/raw/v1.0.0-RC1/coursier


### PR DESCRIPTION
Without this on `Ubuntu 16.04.2 LTS` and `mktemp (GNU coreutils) 8.25` I get the following error:

```
mktemp: too few X's in template ‘coursier’
```