### PR TITLE
Take compiler flags using the option `-scalac-option`

### DIFF
--- a/cli/src/main/scala/jupyter/scala/JupyterScala.scala
+++ b/cli/src/main/scala/jupyter/scala/JupyterScala.scala
@@ -13,6 +13,7 @@ import com.typesafe.scalalogging.LazyLogging
 case class JupyterScalaApp(
   id: String = "scala",
   name: String = "Scala",
+  scalacOption: List[String] = Nil,
   // @ExtraName("d")
   //   dependency: List[String],
   // @ExtraName("r")
@@ -20,7 +21,6 @@ case class JupyterScalaApp(
   @Recurse
     options: ServerAppOptions
 ) extends App with LazyLogging {
-
   def readFully(is: InputStream) = {
     val buffer = new ByteArrayOutputStream()
 
@@ -95,7 +95,7 @@ case class JupyterScalaApp(
     name = name,
     "scala",
     new InterpreterKernel {
-      def apply() = new Interp
+      def apply() = new Interp(scalacOption)
     },
     mainJar,
     isJar = true,

--- a/kernel/src/main/scala/jupyter/scala/Interp.scala
+++ b/kernel/src/main/scala/jupyter/scala/Interp.scala
@@ -13,7 +13,7 @@ import jupyter.kernel.interpreter.Interpreter.IsComplete
 
 import scala.util.Try
 
-class Interp extends jupyter.kernel.interpreter.Interpreter with LazyLogging {
+class Interp(scalacOptions: List[String]) extends jupyter.kernel.interpreter.Interpreter with LazyLogging {
 
 
   def defaultPredef = true
@@ -94,6 +94,8 @@ class Interp extends jupyter.kernel.interpreter.Interpreter with LazyLogging {
   )
 
   interp.init()
+
+  interp.compiler.compiler.settings.processArguments(scalacOptions, processAll = true)
 
   private def capturingOutput[T](t: => T): T =
     Capture(


### PR DESCRIPTION
This commit adds the ability for the kernel to take any number of scalac compiler flags given by `--scalac-option -Xopt1 --scalac-option -Yopt2` etc.

It's not very pretty but at least it's possible to do things like enable `-Ypartial-unification`.