### PR TITLE
Fix authenticated jars access from spark

### DIFF
--- a/spark/core/src/main/scala/jupyter/spark/internals/Spark.scala
+++ b/spark/core/src/main/scala/jupyter/spark/internals/Spark.scala
@@ -86,7 +86,7 @@ object Spark {
     )
 
     helper.fetch(sources = false, javadoc = false, artifactTypes = Set("jar"))
-      .map(_.getAbsolutePath)
+      .map(_.getAbsoluteFile.toURI.toASCIIString)
   }
 
 }


### PR DESCRIPTION
When coursier is caching artifacts from secured repositories, the path looks like
```
~/.coursier/cache/v1/https/<user>%40<repo>/...
```
When such path is added to a spark context directly, it messes up with url encoding and decoding. Internally spark calls `new URI(fileName).getPath` that treats `fileName` as an URL encoded string and decodes it to `.../<user>@<repo>/...` which is not the correct file name.

To overcome this we can convert file name to the `file:` URI `file:/.../<user>%2540<repo>/...` which makes explicit that we want to treat the string as an URL rather than as a file name. 